### PR TITLE
fix: session_alive check

### DIFF
--- a/src/iitkgp_erp_login/erp.py
+++ b/src/iitkgp_erp_login/erp.py
@@ -253,4 +253,4 @@ def session_alive(session: requests.Session):
     """Checks if a session is alive."""
     response = session.get(WELCOMEPAGE_URL)
     content_length = response.headers.get("Content-Length")
-    return content_length == '1034'
+    return content_length == '741'


### PR DESCRIPTION
# Description

Fix the `session_alive` check to check if a session is alive. It uses the `WELCOME_PAGE` url, which redirects to the login page if you are NOT logged in, and returns a 404 page if you are logged in.

<img width="522" height="504" alt="image" src="https://github.com/user-attachments/assets/087f1024-89ea-4325-aacc-c9b0af9fb372" />

Currently, the Content-Length of the returned 404 page seems to be 741.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

This fixes the restoring of saved sessions properly, which did not work earlier.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
